### PR TITLE
allow deleting default quota in snappcloud namespaces

### DIFF
--- a/custom_webhooks/resourcequota_webhook.go
+++ b/custom_webhooks/resourcequota_webhook.go
@@ -18,19 +18,20 @@ type ResourceQuotaValidator struct {
 }
 
 const (
-	teamLabel    = "snappcloud.io/team"
-	enforceLabel = "quota.snappcloud.io/enforce"
+	teamLabel          = "snappcloud.io/team"
+	enforceLabel       = "quota.snappcloud.io/enforce"
+	snappcloudTeamName = "snappcloud"
 )
 
 func (v *ResourceQuotaValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	log := log.FromContext(ctx)
+	ns := &corev1.Namespace{}
+	err := v.Client.Get(context.TODO(), types.NamespacedName{Name: req.Namespace}, ns)
+	if err != nil {
+		log.Error(err, "error getting namespace", "name", req.Namespace)
+		return admission.Denied("error on getting namespace")
+	}
 	if req.Operation == "UPDATE" {
-		ns := &corev1.Namespace{}
-		err := v.Client.Get(context.TODO(), types.NamespacedName{Name: req.Namespace}, ns)
-		if err != nil {
-			log.Error(err, "error getting namespace", "name", req.Namespace)
-			return admission.Denied("error on getting namespace")
-		}
 		if l, ok := ns.GetLabels()[enforceLabel]; ok {
 			if l == "true" {
 				return admission.Allowed("updating resourcequota")
@@ -51,7 +52,11 @@ func (v *ResourceQuotaValidator) Handle(ctx context.Context, req admission.Reque
 			return admission.Allowed("updating resourcequota")
 		}
 	} else if req.Operation == "DELETE" {
-		if req.Name == "default" {
+		teamName, ok := ns.GetLabels()[teamLabel]
+		if !ok {
+			return admission.Denied("no team found for the project. please join your project to a team")
+		}
+		if req.Name == "default" && teamName != snappcloudTeamName {
 			return admission.Denied("default resourcequota cannot be deleted")
 		}
 		return admission.Allowed("DELETE")

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -67,8 +68,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
-		MetricsBindAddress:     metricsAddr,
-		Port:                   9443,
+		Metrics:                server.Options{BindAddress: metricsAddr},
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "bc6545ad.snappcloud.io",


### PR DESCRIPTION
This pr allow users to delete `default` quota in namespaces owned by 'snappcloud' team