### PR TITLE
Allow to delete namespaces having no team

### DIFF
--- a/custom_webhooks/resourcequota_webhook.go
+++ b/custom_webhooks/resourcequota_webhook.go
@@ -52,12 +52,13 @@ func (v *ResourceQuotaValidator) Handle(ctx context.Context, req admission.Reque
 			return admission.Allowed("updating resourcequota")
 		}
 	} else if req.Operation == "DELETE" {
-		teamName, ok := ns.GetLabels()[teamLabel]
-		if !ok {
-			// It's OK to delete namespaces having no team.
-			return admission.Allowed("DELETE")
-		}
-		if req.Name == "default" && teamName != snappcloudTeamName {
+		if req.Name == "default" {
+			teamName, ok := ns.GetLabels()[teamLabel]
+			if ok {
+				if teamName == snappcloudTeamName {
+					return admission.Allowed("DELETE")
+				}
+			}
 			return admission.Denied("default resourcequota cannot be deleted")
 		}
 		return admission.Allowed("DELETE")

--- a/custom_webhooks/resourcequota_webhook.go
+++ b/custom_webhooks/resourcequota_webhook.go
@@ -54,7 +54,8 @@ func (v *ResourceQuotaValidator) Handle(ctx context.Context, req admission.Reque
 	} else if req.Operation == "DELETE" {
 		teamName, ok := ns.GetLabels()[teamLabel]
 		if !ok {
-			return admission.Denied("no team found for the project. please join your project to a team")
+			// It's OK to delete namespaces having no team.
+			return admission.Allowed("DELETE")
 		}
 		if req.Name == "default" && teamName != snappcloudTeamName {
 			return admission.Denied("default resourcequota cannot be deleted")


### PR DESCRIPTION
This PR removes the "deny" line which prevents namespaces having no team.